### PR TITLE
Install vespa-cli from release on GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ ENV M2_HOME="/usr/lib/apache-maven-3.6.1"
 ENV PATH="${M2_HOME}/bin:${PATH}"
 
 # Install vespa-cli
-ENV VESPA_CLI_VERSION="7.469.18"
+ENV VESPA_CLI_VERSION=$(curl -fsSL https://api.github.com/repos/vespa-engine/vespa/releases/latest | grep -Po '"tag_name": "v\K.*?(?=")')
 RUN curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt
 RUN ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,8 @@ RUN echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk" >> /etc/profile.d/jdk-e
 RUN curl -sLf -o - "https://archive.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz" | tar -C /usr/lib -zxf -
 ENV M2_HOME="/usr/lib/apache-maven-3.6.1"
 ENV PATH="${M2_HOME}/bin:${PATH}"
+
+# Install vespa-cli
+ENV VESPA_CLI_VERSION="7.469.18"
+RUN curl -fsSL https://github.com/vespa-engine/vespa/releases/download/v${VESPA_CLI_VERSION}/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64.tar.gz | tar -zxf - -C /opt
+RUN ln -sf /opt/vespa-cli_${VESPA_CLI_VERSION}_linux_amd64/bin/vespa /usr/local/bin/


### PR DESCRIPTION
@aressem FYI - I think you said only sample-apps use this image as well

I guess we can revert https://github.com/vespa-engine/documentation/commit/85b7bee9a686ed7927dac5e3609edfaeb5ccf06c once this is built
