### PR TITLE
Set docker registry on login since buildah does not default to docker…

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -50,7 +50,7 @@ jobs:
       - publish: |
           if [[ -z $SD_PULL_REQUEST ]]; then
             set +x
-            buildah login --username aressem --password "$DOCKER_HUB_DEPLOY_KEY"
+            buildah login --username aressem --password "$DOCKER_HUB_DEPLOY_KEY" docker.io
             set -x
 
             buildah manifest push --all --format v2s2 "$CONTAINER_IMAGE:$CONTAINER_TAG" "docker://$CONTAINER_IMAGE:$CONTAINER_TAG"


### PR DESCRIPTION
….io.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
